### PR TITLE
Fix two windings transformer equations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 _site
 .sass-cache
 Gemfile.lock
+.jekyll-metadata
 

--- a/docs/iidm/model/twoWindingsTransformer.md
+++ b/docs/iidm/model/twoWindingsTransformer.md
@@ -39,7 +39,7 @@ b=b_{nom}.\left(1+\frac{b_{r, tap} + b_{\phi, tap}}{100}\right)\\
 z=r+j.x\\
 y=g+j.b\\
 V_{0}=V_{1}.\rho e^{j\alpha}\\
-I_{0}=\frac{I_{1}}{\rho e^{j\alpha}}\\
+I_{0}=\frac{-I_{1}}{\rho e^{j\alpha}}\\
 $$
 
 the equations of the two windings transformer, in complex notations, are as follow:
@@ -49,7 +49,7 @@ $$
 I_{1}\\
 I_{2}
 \end{array}\right)=\left(\begin{array}{cc}
-\rho\text{²}e^{2j\alpha}(y+\frac{1}{z}) & -\rho e^{j\alpha}\frac{1}{z}\\
+\rho\text{²}e^{2j\alpha}(y+\frac{1}{z}) & -\rho e^{-j\alpha}\frac{1}{z}\\
 -\rho e^{j\alpha}\frac{1}{z} & \frac{1}{z}
 \end{array}\right)\left(\begin{array}{c}
 V_{1}\\

--- a/docs/iidm/model/twoWindingsTransformer.md
+++ b/docs/iidm/model/twoWindingsTransformer.md
@@ -39,7 +39,7 @@ b=b_{nom}.\left(1+\frac{b_{r, tap} + b_{\phi, tap}}{100}\right)\\
 z=r+j.x\\
 y=g+j.b\\
 V_{0}=V_{1}.\rho e^{j\alpha}\\
-I_{0}=\frac{-I_{1}}{\rho e^{j\alpha}}\\
+I_{0}=\frac{-I_{1}}{\rho e^{-j\alpha}}\\
 $$
 
 the equations of the two windings transformer, in complex notations, are as follow:
@@ -49,7 +49,7 @@ $$
 I_{1}\\
 I_{2}
 \end{array}\right)=\left(\begin{array}{cc}
-\rho\text{²}e^{2j\alpha}(y+\frac{1}{z}) & -\rho e^{-j\alpha}\frac{1}{z}\\
+\rho\text{²}(y+\frac{1}{z}) & -\rho e^{-j\alpha}\frac{1}{z}\\
 -\rho e^{j\alpha}\frac{1}{z} & \frac{1}{z}
 \end{array}\right)\left(\begin{array}{c}
 V_{1}\\


### PR DESCRIPTION
Proposed a fix for two windings transformer equations.

Starting from definitions S=VI* and S<sub>0</sub> = -S<sub>1</sub>, 
We have V<sub>0</sub>I<sup>\*</sup><sub>0</sub>=-V<sub>1</sub>I<sup>\*</sup><sub>1</sub>.
From there we have I<sub>0</sub>=-I<sub>1</sub>/(&rho;e<sup>j&alpha;</sup>)<sup>*</sup>,
And then I<sub>0</sub>=-I<sub>1</sub>/&rho;e<sup>-j&alpha;</sup>

The rest of adjustments to the elements of the admittance matrix are derived from this.
