### PR TITLE
[WIP] Package generation - Issue #384

### DIFF
--- a/docs/installation/itools-packager.md
+++ b/docs/installation/itools-packager.md
@@ -24,7 +24,8 @@ The layout of such distribution is the following:
 
 # Goals overview
 The `itools-packager` only has one goal.
-- The `package-zip` goal creates a zip package based on `iTools`
+- The `package` goal creates a compressed package based on `iTools` with three types of output compression format:
+zip, tar.gz, tar.bz2.
 
 # Configuration
 
@@ -32,7 +33,7 @@ The `itools-packager` only has one goal.
 
 ### archiveName
 The `archiveName` property defines the basename of the archive. If this property is not set, `itools-packager` uses the
-packageName.
+packageName. The iTools-packager supports three types of output compression format: zip, tar.gz, tar.bz2.
 
 ### packageName
 The `packageName` property defines the name of the root folder of the distribution. If this property is not set,
@@ -74,7 +75,7 @@ The `copyToEtc` property defines the list of files to copy in the `etc` director
                 <execution>
                     <phase>package</phase>
                     <goals>
-                        <goal>package-zip</goal>
+                        <goal>package</goal>
                     </goals>
                 </execution>
             </executions>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
https://github.com/powsybl/powsybl-core/issues/384

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
docs update

**What is the current behavior?** *(You can also link to an open issue here)*
iTools packager supports only zip packages

**What is the new behavior (if this is a feature change)?**
iTools packager supports zip, tar.bz2 and tar.gz packages

**Does this PR introduce a breaking change ?** *(What changes might users need to make in their application due to this PR?)*
6 possibilities of generation of the package file with packageNameNotNull = "powsybl" :
1- if archiveName = null then archiveNameNotNull = “powsybl”
-> Generate package file : powsybl.zip

2- if archiveName = “file2” then archiveNameNotNull = “file2”
-> Generate package file : file2.zip

3- if archiveName = “file3.zip” then archiveNameNotNull = “file3.zip”
-> Generate package file : file3.zip

4- if archiveName = “file4.tar.gz” then archiveNameNotNull = “file4.tar.gz”
-> Generate package file : file4.tar.gz

5- if archiveName = “file5.tar.bz2” then archiveNameNotNull = “file5.tar.bz2”
-> Generate package file : file5.tar.bz2

6- if archiveName = “file6.tar.error” then archiveNameNotNull = “file6.tar.error”
-> No Generation of the package file with the error message "java.lang.NullPointerException".

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
