### PR TITLE
Correct 404 error on tutorials page

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -22,7 +22,7 @@ menu:
       - name: "Capacity calculation for RSC"
         url: "/docs/user_stories/capacity_calculation_rsc.html"
       - name: "Tutorials"
-        url: "/docs/tutorials.html"
+        url: "/docs/tutorials/index.html"
 
   - name: "Functional documentation"
     icon: "fas fa-square"

--- a/_data/sidebar.yml.bck
+++ b/_data/sidebar.yml.bck
@@ -134,4 +134,4 @@ toc:
       - name: "API Reference"
         url: "#"
       - name: "Tutorials"
-        url: "/docs/tutorials"
+        url: "/docs/tutorials/index"


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix. The tutorials page (accessed from the sidebar) was returning a 404 error. Now it gives access to the tutorials' index page.

