### PR TITLE
Restore search field on mobile.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -8,13 +8,19 @@
     <a class="navbar-brand" href="/">
         <img src="/assets/images/logo_lfe_powsybl.svg" height="30" alt="">
     </a>
-    <ul class="navbar-nav ml-auto">
-        <a class="nav-link mx-1" href="https://github.com/powsybl" target="_blank" rel="noopener" aria-label="GitHub" data-toggle="tooltip" data-placement="bottom" title="GitHub"><i class="fab fa-github"></i></a>
-        <a class="nav-link mx-1" href="https://spectrum.chat/powsybl" target="_blank" rel="noopener" aria-label="Spectrum" data-toggle="tooltip" data-placement="bottom" title="Spectrum"><i class="fas fa-comment"></i></a>
-        <a class="nav-link mx-1" href="https://lists.lfenergy.org/g/powsybl" target="_blank" rel="noopener" aria-label="Mailing Lists" data-toggle="tooltip" data-placement="bottom" title="Mailing Lists"><i class="fas fa-envelope"></i></a>
-        <a class="nav-link mx-1 d-block d-md-none" href="/search"><i class="fas fa-search"></i></a>
-    </ul>
-    <form class="form-inline" action="/search" method="get">
-        <input id="search-box" name="query" class="form-control d-none d-md-block ml-3" type="text" placeholder="Search" aria-label="Search" />
-    </form>
+    <div class="row" style="margin-left: auto;">
+        <div class="col-sm">
+            <ul class="navbar-nav ml-auto">
+                <a class="nav-link mx-1" href="https://github.com/powsybl" target="_blank" rel="noopener" aria-label="GitHub" data-toggle="tooltip" data-placement="bottom" title="GitHub"><i class="fab fa-github"></i></a>
+                <a class="nav-link mx-1" href="https://spectrum.chat/powsybl" target="_blank" rel="noopener" aria-label="Spectrum" data-toggle="tooltip" data-placement="bottom" title="Spectrum"><i class="fas fa-comment"></i></a>
+                <a class="nav-link mx-1" href="https://lists.lfenergy.org/g/powsybl" target="_blank" rel="noopener" aria-label="Mailing Lists" data-toggle="tooltip" data-placement="bottom" title="Mailing Lists"><i class="fas fa-envelope"></i></a>
+                <a id="search-icon" class="nav-link mx-1 d-block d-md-none" href="/search"><i class="fas fa-search"></i></a>
+            </ul>
+        </div>
+        <div class="col-sm">
+            <form class="form-inline" action="/search" method="get">
+                <input id="search-box" name="query" class="form-control {% if page.title != "Search"  %}d-none{% endif %} d-md-block ml-3" type="text" placeholder="Search" aria-label="Search" />
+            </form>
+        </div>
+    </div>
 </nav>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,26 +1,32 @@
 <nav class="navbar navbar-expand navbar-light bg-light fixed-top">
-    {% if page.sidebar %}
-        <button id="sidebarToggler" class="navbar-toggler d-block d-lg-none border-0 mr-3" type="button">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-    {% endif %}
+    <div class="row no-gutters" style="flex-grow:1;">
+        <div class="col-auto mr-auto align-self-center">
+            {% if page.sidebar %}
+                <button id="sidebarToggler" class="navbar-toggler d-inline d-lg-none border-0 mr-0 pl-0" type="button">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+            {% endif %}
 
-    <a class="navbar-brand" href="/">
-        <img src="/assets/images/logo_lfe_powsybl.svg" height="30" alt="">
-    </a>
-    <div class="row" style="margin-left: auto;">
-        <div class="col-sm">
-            <ul class="navbar-nav ml-auto">
-                <a class="nav-link mx-1" href="https://github.com/powsybl" target="_blank" rel="noopener" aria-label="GitHub" data-toggle="tooltip" data-placement="bottom" title="GitHub"><i class="fab fa-github"></i></a>
-                <a class="nav-link mx-1" href="https://spectrum.chat/powsybl" target="_blank" rel="noopener" aria-label="Spectrum" data-toggle="tooltip" data-placement="bottom" title="Spectrum"><i class="fas fa-comment"></i></a>
-                <a class="nav-link mx-1" href="https://lists.lfenergy.org/g/powsybl" target="_blank" rel="noopener" aria-label="Mailing Lists" data-toggle="tooltip" data-placement="bottom" title="Mailing Lists"><i class="fas fa-envelope"></i></a>
-                <a id="search-icon" class="nav-link mx-1 d-block d-md-none" href="/search"><i class="fas fa-search"></i></a>
-            </ul>
+            <a class="navbar-brand mr-0" href="/">
+                <img src="/assets/images/logo_lfe_powsybl.svg" height="30" alt="">
+            </a>
         </div>
-        <div class="col-sm">
-            <form class="form-inline" action="/search" method="get">
-                <input id="search-box" name="query" class="form-control {% if page.title != "Search"  %}d-none{% endif %} d-md-block ml-3" type="text" placeholder="Search" aria-label="Search" />
-            </form>
+        <div class="col-5 col-sm-auto">
+            <div class="row no-gutters">
+                <div class="col-sm-auto">
+                    <ul class="navbar-nav ml-auto">
+                        <a class="nav-link mx-1" href="https://github.com/powsybl" target="_blank" rel="noopener" aria-label="GitHub" data-toggle="tooltip" data-placement="bottom" title="GitHub"><i class="fab fa-github"></i></a>
+                        <a class="nav-link mx-1" href="https://spectrum.chat/powsybl" target="_blank" rel="noopener" aria-label="Spectrum" data-toggle="tooltip" data-placement="bottom" title="Spectrum"><i class="fas fa-comment"></i></a>
+                        <a class="nav-link mx-1" href="https://lists.lfenergy.org/g/powsybl" target="_blank" rel="noopener" aria-label="Mailing Lists" data-toggle="tooltip" data-placement="bottom" title="Mailing Lists"><i class="fas fa-envelope"></i></a>
+                        <a id="search-icon" class="nav-link mx-1 d-block d-sm-none" href="/search"><i class="fas fa-search"></i></a>
+                    </ul>
+                </div>
+                <div class="col-sm-auto">
+                    <form class="form-inline" action="/search" method="get">
+                        <input id="search-box" name="query" class="form-control {% if page.title != "Search"  %}d-none{% endif %} d-sm-block ml-3" type="text" placeholder="Search" aria-label="Search" />
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
 </nav>

--- a/assets/css/powsybl/_navbar.scss
+++ b/assets/css/powsybl/_navbar.scss
@@ -11,3 +11,9 @@
 .content {
   margin-top: $navbar-height;
 }
+
+@media screen and (max-width: 575.98px) {
+    #search-box {
+      height: 22px;
+    }
+}

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -4,3 +4,10 @@ $(function () {
         $('.overlay').toggleClass('active');
     });
 });
+
+$(function () {
+    $('#search-icon').click(function(e) {
+        e.preventDefault();
+        $('#search-box').toggleClass("d-none");
+    });
+});


### PR DESCRIPTION
This is a bit of a hack, feel free to improve if you know bootstrap4

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Impossible to search on mobile


**What is the new behavior (if this is a feature change)?**
Possible to search

on wide screens you get:
![Capture d’écran de 2019-11-20 14-40-33](https://user-images.githubusercontent.com/89208/69243772-0387e080-0ba4-11ea-8099-7570f86bb7ab.png)


on small screens:
![Capture d’écran de 2019-11-20 14-40-45](https://user-images.githubusercontent.com/89208/69243801-100c3900-0ba4-11ea-893e-65ef64cb5d66.png)

after clicking the search icon:
![Capture d’écran de 2019-11-20 14-40-49](https://user-images.githubusercontent.com/89208/69243813-17cbdd80-0ba4-11ea-82cf-8fda66612ad5.png)


On the search page on small screens, the search field is automatically visible

It's ugly.