### PR TITLE
Search: display an error if no javascript

### DIFF
--- a/search.md
+++ b/search.md
@@ -3,6 +3,7 @@ layout: default
 title: Search
 ---
 
+<noscript><h2>ERROR</h2>You need JavaScript to search.</noscript>
 <div id="search-results"></div>
 
 <script>


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
"Docs"


**What is the current behavior?** *(You can also link to an open issue here)*
without javascript, the search page is blank


**What is the new behavior (if this is a feature change)?**
Without javascript, an error is shown


