### PR TITLE
Remove the skip-postproc option from the tools

### DIFF
--- a/docs/tools/loadflow.md
+++ b/docs/tools/loadflow.md
@@ -12,7 +12,7 @@ usage: itools [OPTIONS] loadflow --case-file <FILE> [-E <property=value>]
               [--export-parameters <EXPORT_PARAMETERS>] [--help] [-I <property=value>]
               [--import-parameters <IMPORT_PARAMETERS>] [--output-case-file <FILE>]
               [--output-case-format <CASEFORMAT>] [--output-file <FILE>]
-              [--output-format <FORMAT>] [--parameters-file <FILE>] [--skip-postproc]
+              [--output-format <FORMAT>] [--parameters-file <FILE>]
 
 Available options are:
     --config-name <CONFIG_NAME>   Override configuration file name

--- a/docs/tools/loadflow.md
+++ b/docs/tools/loadflow.md
@@ -33,9 +33,6 @@ Available arguments are:
      --output-format <FORMAT>                     loadflow results output format
                                                   [CSV, JSON]
      --parameters-file <FILE>                     loadflow parameters as JSON file
-     --skip-postproc                              skip network importer post
-                                                  processors (when configured)
-
 ```
 
 ## Required parameters
@@ -74,10 +71,6 @@ parameter is required if the `output-file` parameter is used.
 ### parameters-file
 Use the `--parameters-file` parameter to specify a JSON configuration file. If this parameter is not set, the default
 configuration is used.
-
-### skip-postproc
-Use the `--skip-postproc` parameter to skip the importer's post processors. Read the [post processor](../iidm/importer/post-processor/index.md)
-documentation page to learn more about importer's post processors.
 
 # Configuration
 To run a load flow, one has to choose the implementation, follow the instructions at [LoadFlow Configuration](../configuration/modules/load-flow.md).

--- a/docs/tools/security-analysis.md
+++ b/docs/tools/security-analysis.md
@@ -33,8 +33,6 @@ Available arguments are:
     --output-file <FILE>                               the output path
     --output-format <FORMAT>                           the output format [JSON]
     --parameters-file <FILE>                           loadflow parameters as JSON file
-    --skip-postproc                                    skip network importer post
-                                                       processors (when configured)
     --with-extensions <EXTENSIONS>                     the extension list to enable
 
 Allowed LIMIT-TYPES values are [CURRENT, LOW_VOLTAGE, HIGH_VOLTAGE,
@@ -85,10 +83,6 @@ Use the `--output-format` parameter to specify the format of the output file. Th
 
 ### parameters-file
 Use the `--parameters-file` parameter to specify the path of the configuration file.
-
-### skip-postproc
-Use the `--skip-postproc` parameter to skip the importer's post processors. Read the [post processor](../iidm/importer/post-processor/index.md)
-documentation page to learn more about importer's post processors.
 
 ### with-extensions
 Use the `--with-extensions` parameter to activate a list of `com.powsybl.security.interceptors.SecurityAnalysisInterceptor`

--- a/docs/tools/sensitivity-computation.md
+++ b/docs/tools/sensitivity-computation.md
@@ -31,8 +31,6 @@ Available arguments are:
     --output-file <FILE>                               sensitivity computation results
                                                        output path
     --output-format <FORMAT>                           the output format [JSON]
-    --skip-postproc                                    skip network importer post
-                                                       processors (when configured)
 ```
 
 ## Required parameters
@@ -57,10 +55,6 @@ used, the results are printed to the console.
 ### output-format
 Use the `--output-format` parameter to specify the format of the result file. Currently, the only supported format is JSON. This
 parameter is required if the `output-file` parameter is used.
-
-### skip-postproc
-Use the `--skip-postproc` parameter to skip the importer's post processors. Read the [post processor](../iidm/importer/post-processor/index.md)
-documentation page to learn more about importer's post processors.
 
 # Configuration
 To run a sensitivity computation, one has to configure the the [componentDefaultConfig](../configuration/modules/componentDefaultConfig.md)

--- a/docs/tools/sensitivity-computation.md
+++ b/docs/tools/sensitivity-computation.md
@@ -14,7 +14,6 @@ $> itools sensitivity-computation --help
 usage: itools [OPTIONS] sensitivity-computation --case-file <FILE>
        --factors-file <FILE> [--help] [-I <property=value>] [--import-parameters
        <IMPORT_PARAMETERS>] [--output-file <FILE>] [--output-format <FORMAT>]
-       [--skip-postproc]
 
 Available options are:
     --config-name <CONFIG_NAME>   Override configuration file name


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Doc


**What is the current behavior?** *(You can also link to an open issue here)*
N/A


**What is the new behavior (if this is a feature change)?**
The `skip-postproc` has been removed from the documentation


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
