### PR TITLE
Fix the run method name in the provider section

### DIFF
--- a/pages/documentation/developer/patterns/simulator-integration.md
+++ b/pages/documentation/developer/patterns/simulator-integration.md
@@ -32,11 +32,11 @@ simulations a `DynamicSimulationProvider` interface exists.
 These interfaces inherit from the `Versionable` and the `PlatformConfigNamedProvider` interfaces, and provide two methods:
 - `getName` (inherited from `Versionable`): returns the implementation name, which has to be the one given in the configuration
 - `getVersion` (inherited from `Versionable`): returns the version of the simulator, which may be used to check that the binary for the simulator and the integration code in PowSyBl are compatible
-- `runAsync`: the main method, to launch the simulation
+- `run`: the main method, to launch the simulation
 
 ## Implementation
 
-For each simulator, it is then necessary to implement the `getName`, `getVersion` and `runAsync` methods.
+For each simulator, it is then necessary to implement the `getName`, `getVersion` and `run` methods.
 For example, for load flow simulations, some existing implementations are `OpenLoadFlowProvider` and `Hades2Provider`, and for time-domain simulations the `DynawoProvider` exists.
 
 **Remarks**:

--- a/pages/documentation/developer/patterns/simulator-integration.md
+++ b/pages/documentation/developer/patterns/simulator-integration.md
@@ -63,7 +63,7 @@ The configuration for a simulator consists of several modules:
 
 Regarding the configuration for the simulator choice, the standard in PowSyBl is to proceed as follows:
 - the module name is based on the utility class name: for example `dynamic-simulation` or `load-flow`
-- in that module, the property to be defined to select the implementation is named: `default-impl-name` (see for example the [load flow configuration](../../simulation/powerflow.md#configuration)
+- in that module, the property to be defined to select the implementation is named: `default-impl-name` (see for example the [load flow configuration](../../simulation/powerflow/index.md#configuration)
 
 ### Simulator configuration
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Doc update


**What is the current behavior?** *(You can also link to an open issue here)*
The method name to implement in the providers is not `runAsync` but `run`.


**What is the new behavior (if this is a feature change)?**
This PR fix the documentation


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
