### PR TITLE
Fix dead-link to grid suite page

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@ layout: base
                             <p>A suite of web-based tools for grid simulation and analysis</p>
                             <div class="portfolio-links">
                                 <!--<a href="/assets/img/portfolio/gridsuite.png" data-gall="portfolioGallery" class="venobox" title="GridSuite illustration"><i class="bx bx-plus"></i></a>-->
-                                <a href="/pages/projects/grid-suite.html" title="More Details"><i class="bx bx-link"></i></a>
+                                <a href="/pages/projects/gridsuite.html" title="More Details"><i class="bx bx-link"></i></a>
                                 <a href="https://github.com/gridsuite" title="GitHub"><i class="bx bxl-github"></i></a>
                             </div>
                         </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The link to grid suite on the home page is dead


**What is the new behavior (if this is a feature change)?**
The link is now working


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
