### PR TITLE
Change default  values of parameters dcUseTransformerRatio and voltageRemoteControl

### DIFF
--- a/pages/documentation/simulation/powerflow/hades2.md
+++ b/pages/documentation/simulation/powerflow/hades2.md
@@ -82,7 +82,7 @@ this parameter is `1`.
 
 **dcUseTransformerRatio**  
 The `dcUseTransformerRatio` property is an optional property that defines if ratio of transformers should be used in the
-flow equations. The default value of this parameter is `false`.
+flow equations. The default value of this parameter is `true`.
 
 **dcVoltageCoeff225**  
 The `dcVoltageCoeff225` property is an optional property that defines the multiplication factor of the nominal voltage

--- a/pages/documentation/simulation/powerflow/hades2.md
+++ b/pages/documentation/simulation/powerflow/hades2.md
@@ -82,7 +82,7 @@ this parameter is `1`.
 
 **dcUseTransformerRatio**  
 The `dcUseTransformerRatio` property is an optional property that defines if ratio of transformers should be used in the
-flow equations. The default value of this parameter is `true`.
+flow equations. The default value of this parameter is `true`. It used to be false until the version 2.15.0 of `hades2-integration`.
 
 **dcVoltageCoeff225**  
 The `dcVoltageCoeff225` property is an optional property that defines the multiplication factor of the nominal voltage

--- a/pages/documentation/simulation/powerflow/openlf.md
+++ b/pages/documentation/simulation/powerflow/openlf.md
@@ -104,7 +104,7 @@ In that case, the remaining active power mismatch remains on the selected slack 
 
 **voltageRemoteControl**  
 The `voltageRemoteControl` property is an optional property that defines if the remote control for voltage controllers has to be modeled.
-The default value is `false`.
+The default value is `true`.
 
 **slackBusSelectorType**  
 The `slackBusSelectorType` property is an optional property that defines how to select the slack bus. The three options are available through the configuration file:
@@ -148,10 +148,7 @@ If `balanceType` equals to `PROPORTIONAL_TO_CONFORM_LOAD`, the power factor rema
 The default value for `loadPowerFactorConstant` property is `false`.
 
 **dcUseTransformerRatio**  
-The `dcUseTransformerRatio` property is an optional property that defines if ratio of transformers should be used in the flow equations during DC approximation. The default value of this parameter is `false`.
-
-**updateFlows**  
-The `updateFlows` property is an optional property that defines if flows have to be updated after a DC load flows computation.
+The `dcUseTransformerRatio` property is an optional property that defines if ratio of transformers should be used in the flow equations during DC approximation. The default value of this parameter is `true`.
 
 ### Configuration file example
 See below an extract of a config file that could help:


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

It documentes the changes on hades2 integration and on open-loadflow where the default values are `false` for `dcUseTransformerRatio`. `true` is a more reasonnable choice because the simulation is more accurate. It changes also the default value of parameter `remoteVoltageControl` on open loadflow side to ``true` because it is also more accurate.

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
