### PR TITLE
Fix run-script mistake (args vs argv)

### DIFF
--- a/pages/documentation/user/itools/run-script.md
+++ b/pages/documentation/user/itools/run-script.md
@@ -107,8 +107,8 @@ The following example shows how to load a network from a file, run a [power flow
 ```groovy
 import com.powsybl.loadflow.LoadFlowParameters.VoltageInitMode
 
-input_file = argv[1]
-output_file = argv[2]
+input_file = args[1]
+output_file = args[2]
 
 // Load a network file
 network = loadNetwork(input_file)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Doc fix


**What is the current behavior?** *(You can also link to an open issue here)*
One of the example in run-script tool documentation page refers that the keyword to get the arguments is `argv`. This is a mistake: the correct name is `args`, like in the previous example.


**What is the new behavior (if this is a feature change)?**
Documentation is fixed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
