### PR TITLE
Fix network extraction documentation pages

### DIFF
--- a/pages/documentation/developer/api_guide/extraction.md
+++ b/pages/documentation/developer/api_guide/extraction.md
@@ -1,14 +1,10 @@
 # Network reduction
 
-The network reduction is relying on a `NetworkPredicate` instance, to define an area of interest (i.e. a list
-of equipments to keep in the network after the reduction). The equipments outside this area will be removed and the
-lines, transformers and HVDC lines connecting voltage levels inside and outside this area will be replaced by injections
-(loads or dangling lines, depending on the implementation).
+The network reduction is relying on a `NetworkPredicate` instance, to define an area of interest (i.e. a list of equipments to keep in the network after the reduction). The equipments outside this area will be removed and the lines, transformers and HVDC lines connecting voltage levels inside and outside this area will be replaced by injections (loads or dangling lines, depending on the implementation).
 
 ## Define an area of interest
 
-Before doing the reduction, one has to define the area of interest, using the `com.powsybl.iidm.reducer.NetworkPredicate`
-interface. This interface declares two methods:
+Before doing the reduction, one has to define the area of interest, using the `com.powsybl.iidm.reducer.NetworkPredicate` interface. This interface declares two methods:
 ```java
 public interface NetworkPredicate {
 
@@ -18,26 +14,21 @@ public interface NetworkPredicate {
 }
 ```
 
-These two methods must return `true` when the given parameter (a [substation](../model/substation.md) or a [voltage level](../model/voltageLevel.md))
-is in the area of interest and should still be in the network after the reduction.
+These two methods must return `true` when the given parameter (a [substation](../../grid/model/index.md#substation) or a [voltage level](../../grid/model/index.md#voltage-level)) is in the area of interest and should still be in the network after the reduction.
 
 PowSyBl provides two implementations of this interface:
-- the `IdentifierNetworkPredicate` implementation defines an area of interest using a list of voltage levels or
-substation IDs
+- the `IdentifierNetworkPredicate` implementation defines an area of interest using a list of voltage levels or substation IDs
 - the `NominalVoltageNetworkPredicate` implementation defines an area of interest using a range of nominal voltages 
 
 You can also provide your own implementation.
 
 ### By IDs
 
-The `com.powsybl.iidm.reducer.IdentifierNetworkPredicate` class is an implementation of the `NetworkPredicate` interface
-that contains a set of substations' or voltage levels' IDs.
+The `com.powsybl.iidm.reducer.IdentifierNetworkPredicate` class is an implementation of the `NetworkPredicate` interface that contains a set of substations' or voltage levels' IDs.
 
-The `boolean test(Substation substation)` method returns true if the ID of the given substation is contained in the set of
-IDs, or at least one of the voltage levels IDs of the given substation is found in the set of IDs.
+The `boolean test(Substation substation)` method returns true if the ID of the given substation is contained in the set of IDs, or at least one of the voltage levels IDs of the given substation is found in the set of IDs.
 
-The `boolean test(VoltageLevel voltageLevel)` method returns true if the ID of the given voltage level or the ID of its
-substation is found in the set of IDs.
+The `boolean test(VoltageLevel voltageLevel)` method returns true if the ID of the given voltage level or the ID of its substation is found in the set of IDs.
 
 #### Examples
 
@@ -68,14 +59,11 @@ NetworkPredicate p3 = new IdentifierNetworkPredicate(
 
 ### By nominal voltages
 
-The `com.powsybl.iidm.reducer.NominalVoltageNetworkPredicate` class is an implementation of the `NetworkPredicate`
-interface that contains two double values that define a range of nominal voltages.
+The `com.powsybl.iidm.reducer.NominalVoltageNetworkPredicate` class is an implementation of the `NetworkPredicate` interface that contains two double values that define a range of nominal voltages.
 
-The `boolean test(Substation substation)` method returns true if at least one of the voltage levels of the given substation
-has its nominal voltage inside the range.
+The `boolean test(Substation substation)` method returns true if at least one of the voltage levels of the given substation has its nominal voltage inside the range.
 
-The `boolean test(Voltage substation)` method returns true if the given voltage level has its nominal voltage inside the
-range.
+The `boolean test(Voltage substation)` method returns true if the given voltage level has its nominal voltage inside the range.
 
 #### Examples
 
@@ -100,21 +88,16 @@ PowSyBl provides a default implementation of this interface, but you can provide
 
 ### Default implementation
 
-The `com.powsybl.iidm.reducer.DefaultNetworkReducer` class is the PowSyBl implementation of the `NetworkReducer` interface
-that replaces the lines in the _border_ group by [loads](../model/load.md) or [dangling lines](../model/danglingLine.md)
-depending on the [options](index.md#options), and the two windings transformers by [loads](../model/load.md).
+The `com.powsybl.iidm.reducer.DefaultNetworkReducer` class is the PowSyBl implementation of the `NetworkReducer` interface that replaces the lines in the _border_ group by [loads](../../grid/model/index.md#load) or [dangling lines](../../grid/model/index.md#dangling-line) depending on the [options](#options), and the two windings transformers by [loads](../../grid/model/index.md#load).
 
-NB: The HVDC lines and the three windings transformers replacement is not supported yet. If the `DefaultNetworkReducer`
-encountered an HVDC line or a three windings transformer, an `UnsupportedOperationException` is thrown.
+NB: The HVDC lines and the three windings transformers replacement is not supported yet. If the `DefaultNetworkReducer` encountered an HVDC line or a three windings transformer, an `UnsupportedOperationException` is thrown.
 
 #### Options
 
-The network reduction can be configured by passing a `com.powsybl.iidm.reducer.ReductionOptions` instance to the
-`DefaultNetworkReducer` constructor.
+The network reduction can be configured by passing a `com.powsybl.iidm.reducer.ReductionOptions` instance to the `DefaultNetworkReducer` constructor.
 
 ##### withDanglingLines
-This option defines whether the equipments in the _border_ group are replaced by dangling lines or by loads. If this option is set to `false`,
-which is the default value, the equipments are exclusively replaced by loads.
+This option defines whether the equipments in the _border_ group are replaced by dangling lines or by loads. If this option is set to `false`, which is the default value, the equipments are exclusively replaced by loads.
 
 ##### Examples
 The following example shows how to create a new `ReductionOptions` instance to do replacements by dangling lines.
@@ -131,12 +114,9 @@ ReductionOptions options = new ReductionOptions()
 
 #### Observers
 
-The `com.powsybl.iidm.reducer.NetworkReducerObserver` is an interface that allows to be notified each time an `Identifiable`
-is removed or replaced. This interface provides several methods, one per `Identifiable` sub class managed by the
-`DefaultNetworkReducer` implementation. There are 2 types of events:
+The `com.powsybl.iidm.reducer.NetworkReducerObserver` is an interface that allows to be notified each time an `Identifiable` is removed or replaced. This interface provides several methods, one per `Identifiable` sub class managed by the `DefaultNetworkReducer` implementation. There are 2 types of events:
 - a _replace_ event, when a line or a two windings transformer is replaced by a load or a danging line
-- a _remove_ event, when a substation, a voltage level, a line, a two or three windings transformer or an HVDC line is
-removed.
+- a _remove_ event, when a substation, a voltage level, a line, a two or three windings transformer or an HVDC line is removed.
 
 ```java
 public interface NetworkReducerObserver {
@@ -164,8 +144,7 @@ public interface NetworkReducerObserver {
 }
 ```
 
-PowSyBl provides a default implementation of the `NetworkReducerObserver` that does nothing. Use it as a base class of
-your own implementation.
+PowSyBl provides a default implementation of the `NetworkReducerObserver` that does nothing. Use it as a base class of your own implementation.
 
 ## Examples
 
@@ -180,9 +159,8 @@ NetworkReducer reducer = NetworkReducer.builder()
 reducer.reduce(network);
 ```
 
-### Network conversion
-This example shows how to do a network reduction, using the `groovy-script` option of the [convert-network](../../tools/convert-network.md)
-command.
+### Groovy scripting
+This example shows how to do a network reduction, using the [run-script](../../user/itools/run-script.md) command.
 
 First, we need a groovy script to do the reduction:
 ```groovy
@@ -190,24 +168,38 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.reducer.IdentifierNetworkPredicate;
 import com.powsybl.iidm.reducer.NetworkReducer;
 
-NetworkReducer reducer = NetworkReducer.builder()
+network = loadNetwork(args[0])
+
+reducer = NetworkReducer.builder()
+        .withNetworkPredicate(IdentifierNetworkPredicate.of("P1"))
+        .build()
+reducer.reduce(network)
+
+saveNetwork("XIIDM", network, null, args[1])
+```
+
+See the [groovy scripts](../../developer/scripting/groovy.md) documentation page for more information about `loadNetwork` and `saveNetwork` functions. 
+
+Then, we run the [groovy-script](../../user/itools/run-script.md) command to apply the previous script to the `network.xiidm` file, and then export the modified network to the `network2.xiidm` file. 
+```shell
+$> ./itools run-script --file extraction.groovy network.xiidm network2.xiidm
+```
+
+### Import post-processor
+This example shows how to automatically reduce networks when they are loaded, using the [groovy post-processors](../../grid/formats/import-post-processor.md#groovy-post-processor) with the same script as above. Note that the script will be applied each time a case file will be loaded. If you want to do it only once, use the [previous method](#groovy-scripting).
+
+The script is a little different from the previous one:
+```groovy
+import com.powsybl.iidm.reducer.IdentifierNetworkPredicate;
+import com.powsybl.iidm.reducer.NetworkReducer;
+
+reducer = NetworkReducer.builder()
         .withNetworkPredicate(IdentifierNetworkPredicate.of("P1"))
         .build()
 reducer.reduce(network)
 ```
 
-Then, we run the [convert-network](../../tools/convert-network.md) command:
-```shell
-$> ./itools convert-network --input-file /home/user/input.xiidm
---output-file /home/user/output.xiidm --output-format XIIDM
---groovy-script /home/user/network-reduction.groovy
-```
-
-### Import post-processor
-This example shows how to automatically reduce networks when they are loaded, using the
-[groovy post-processors](../importer/post-processor/GroovyScriptPostProcessor.md) with the same script as above.
-
-First, we have to configure the groovy post-processor in your configuration file:
+We have to configure the groovy post-processor in your configuration file:
 ```yaml
 import:
     postProcessors: groovyScript
@@ -215,10 +207,9 @@ import:
 groovy-post-processor:
     script: /home/user/network-reduction.groovy
 ```
-For more information about the configuration of the groovy post-processor, please refer to this documentation
-[page](../../configuration/modules/groovy-post-processor.md).
+For more information about the configuration of the groovy post-processor, please refer to this [documentation page](../../grid/formats/import-post-processor.md#groovy-post-processor).
 
-Then, we run the [convert-network](../../tools/convert-network.md) command:
+Then, we run the [convert-network](../../user/itools/convert-network.md) command:
 ```shell
 $> ./itools convert-network --input-file /home/user/input.xiidm
 --output-file /home/user/output.xiidm --output-format XIIDM

--- a/pages/documentation/developer/scripting/groovy.md
+++ b/pages/documentation/developer/scripting/groovy.md
@@ -12,9 +12,6 @@ The first way to use Groovy scripts is to use the [iTools run-script](../../user
 
 It's possible to extend this DSL with user-friendly functions by writing [extensions]().
 
-## powsyblsh
-`powsyblsh` is a script for Linux, provided with a [iTools distribution](../../user/index.md#installation-from-binaries) that run the interactive command line [Groovy Shell](). At start-up, it loads the classes of jars found in the `share/java` folder of the iTools distribution. You should consider this option during implementation phase. Once your script is ready for production, run it with the [iTools run-script](../../user/itools/run-script.md) command.
-
 ## Example
 This small example shows how to load a case file and run a power simulation in Groovy:
 ```groovy

--- a/pages/documentation/grid/features/extraction.md
+++ b/pages/documentation/grid/features/extraction.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+latex: true
 ---
 
 # Network extraction


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Doc update


**What is the current behavior?** *(You can also link to an open issue here)*

The documentation about network extraction and groovy scripting refers to features that have been removed recently.


**What is the new behavior (if this is a feature change)?**

Network extraction links has been fixed
Usage of the network extraction from convert-tools have been updated to use the run-script command
The powsyblsh documentation has been removed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
