### PR TITLE
Fix groovy contingency dsl typo: equipements -> equipments

### DIFF
--- a/pages/documentation/simulation/securityanalysis/contingency-dsl.md
+++ b/pages/documentation/simulation/securityanalysis/contingency-dsl.md
@@ -44,7 +44,7 @@ The following example creates a N-1 contingency for each line of the network. We
 ```groovy
 for (l in network.lines) {
     contingency(l.id) {
-        equipements l.id
+        equipments l.id
     }
 }
 ```


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
docs update


**What is the current behavior?** *(You can also link to an open issue here)*
if you use the script given in the doc, you get groovy.lang.MissingMethodException: No signature of method: static com.powsybl.contingency.dsl.ContingencyDslLoader.equipements() is applicable for argument types: (String) values: [line3]]


**What is the new behavior (if this is a feature change)?**
works


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
