### PR TITLE
Update repositories table following latest releases

### DIFF
--- a/pages/documentation/developer/repositories/index.md
+++ b/pages/documentation/developer/repositories/index.md
@@ -43,11 +43,17 @@ This [repository](https://github.com/powsybl/powsybl-balances-adjustment) provid
 ### [powsybl-single-line-diagram](powsybl-single-line-diagram.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-single-line-diagram.svg)](https://github.com/powsybl/powsybl-single-line-diagram/releases/)
 This [repository](https://github.com/powsybl/powsybl-single-line-diagram) provides modules to generate single line diagrams.
 
-**Reviewers:** [geofjamg](https://github.com/geofjamg), [jonenst](https://github.com/jonenst)
-**Committers:** [geofjamg](https://github.com/geofjamg), [jonenst](https://github.com/jonenst)
+**Reviewers:** [flo-dup](https://github.com/flo-dup), [geofjamg](https://github.com/geofjamg), [jonenst](https://github.com/jonenst)
+**Committers:** [flo-dup](https://github.com/flo-dup), [geofjamg](https://github.com/geofjamg), [jonenst](https://github.com/jonenst)
+
+### [powsybl-entsoe](powsybl-entsoe.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-entsoe.svg)](https://github.com/powsybl/powsybl-entsoe/releases/)
+This [repository](https://github.com/powsybl/powsybl-entsoe) provides components specific to ENTSO-E-orientated processes.
+
+**Reviewers:** [MioRtia](https://github.com/MioRtia), [annetill](https://github.com/annetill), [colinepiloquet](https://github.com/colinepiloquet)
+**Committers:** [MioRtia](https://github.com/MioRtia),  [colinepiloquet](https://github.com/colinepiloquet)
 
 ### [powsybl-metrix](powsybl-metrix.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-metrix.svg)](https://github.com/powsybl/powsybl-metrix/releases/)
-This [repository](https://github.com/powsybl/powsybl-metrix) provides modules provides modules to run optimal power load flow on several network variants. Variants are generated through time series mapping on a base case.
+This [repository](https://github.com/powsybl/powsybl-metrix) provides modules to run optimal power load flow on several network variants. Variants are generated through time series mapping on a base case.
 
 **Reviewers:** [marifunf](https://github.com/marifunf), [berthaultval](https://github.com/berthaultval), [pl-buiquang](https://github.com/pl-buiquang)
 **Committers:** [berthaultval](https://github.com/berthaultval), [MioRtia](https://github.com/MioRtia)
@@ -118,12 +124,12 @@ This [repository](https://github.com/powsybl/powsybl-metrix) provides a C++ impl
 
 ## Development
 
-### [pypowsybl](pypowsybl.md)
+### [pypowsybl](pypowsybl.md) [![GitHub release](https://img.shields.io/github/release/powsybl/pypowsybl.svg)](https://github.com/powsybl/pypowsybl/releases/)
 
 This [repository](https://github.com/powsybl/pypowsybl) provides an integration of the PowSyBl framework for Python developers.
 
-**Reviewers:** [mathbagu](https://github.com/mathbagu), [sylvlecl](https://github.com/sylvlecl)
-**Committers:** [mathbagu](https://github.com/mathbagu), [sylvlecl](https://github.com/sylvlecl)
+**Reviewers:** [geofjamg](https://github.com/geofjamg), [sylvlecl](https://github.com/sylvlecl)  
+**Committers:** [geofjamg](https://github.com/geofjamg), [sylvlecl](https://github.com/sylvlecl)
 
 ### powsybl-incubator
 This [repository](https://github.com/powsybl/powsybl-incubator) provides incubating modules that are not mature enough to be released.

--- a/pages/documentation/developer/repositories/powsybl-afs.md
+++ b/pages/documentation/developer/repositories/powsybl-afs.md
@@ -16,6 +16,8 @@ The PowSyBl AFS (**A**pplication **F**ile **S**ystem) [repository](https://githu
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 3.6.0 | 2021-05-03 | [Release notes](https://github.com/powsybl/powsybl-afs/releases/tag/v3.6.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-afs/3.6.0/index.html) |
+| 3.5.0 | 2021-03-02 | [Release notes](https://github.com/powsybl/powsybl-afs/releases/tag/v3.5.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-afs/3.5.0/index.html) |
 | 3.4.1 | 2021-01-16 | [Release notes](https://github.com/powsybl/powsybl-afs/releases/tag/v3.4.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-afs/3.4.1/index.html) |
 | 3.4.0 | 2020-11-16 | [Release notes](https://github.com/powsybl/powsybl-afs/releases/tag/v3.4.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-afs/3.4.0/index.html) |
 | 3.3.0 | 2020-08-03 | [Release notes](https://github.com/powsybl/powsybl-afs/releases/tag/v3.3.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-afs/3.3.0/index.html) |

--- a/pages/documentation/developer/repositories/powsybl-balances-adjustment.md
+++ b/pages/documentation/developer/repositories/powsybl-balances-adjustment.md
@@ -16,6 +16,9 @@ The PowSyBl Balances Adjustment [repository](https://github.com/powsybl/powsybl-
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 1.5.0 | 2021-05-27 | [Release notes](https://github.com/powsybl/powsybl-balances-adjustment/releases/tag/v1.5.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-balances-adjustment/1.5.0/index.html) |
+| 1.4.0 | 2021-04-20 | [Release notes](https://github.com/powsybl/powsybl-balances-adjustment/releases/tag/v1.4.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-balances-adjustment/1.4.0/index.html) |
+| 1.3.0 | 2021-02-23 | [Release notes](https://github.com/powsybl/powsybl-balances-adjustment/releases/tag/v1.3.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-balances-adjustment/1.3.0/index.html) |
 | 1.2.2 | 2020-09-10 | [Release notes](https://github.com/powsybl/powsybl-balances-adjustment/releases/tag/v1.2.2) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-balances-adjustment/1.2.2/index.html) |
 | 1.2.1 | 2020-08-17 | [Release notes](https://github.com/powsybl/powsybl-balances-adjustment/releases/tag/v1.2.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-balances-adjustment/1.2.1/index.html) |
 | 1.2.0 | 2020-06-29 | [Release notes](https://github.com/powsybl/powsybl-balances-adjustment/releases/tag/v1.2.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-balances-adjustment/1.2.0/index.html) |

--- a/pages/documentation/developer/repositories/powsybl-core.md
+++ b/pages/documentation/developer/repositories/powsybl-core.md
@@ -22,6 +22,9 @@ The PowSyBl Core [repository](https://github.com/powsybl/powsybl-core) provides 
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 4.2.0 | 2021-05-25 | [Release notes](https://github.com/powsybl/powsybl-core/releases/tag/v4.2.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-core/4.2.0/index.html) |
+| 4.1.2 | 2021-04-28 | [Release notes](https://github.com/powsybl/powsybl-core/releases/tag/v4.1.2) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-core/4.1.2/index.html) |
+| 4.1.1 | 2021-04-19 | [Release notes](https://github.com/powsybl/powsybl-core/releases/tag/v4.1.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-core/4.1.1/index.html) |
 | 4.1.0 | 2021-04-08 | [Release notes](https://github.com/powsybl/powsybl-core/releases/tag/v4.1.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-core/4.1.0/index.html) |
 | 4.0.1 | 2021-02-11 | [Release notes](https://github.com/powsybl/powsybl-core/releases/tag/v4.0.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-core/4.0.1/index.html) |
 | 4.0.0 | 2021-02-05 | [Release notes](https://github.com/powsybl/powsybl-core/releases/tag/v4.0.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-core/4.0.0/index.html) |

--- a/pages/documentation/developer/repositories/powsybl-dynawo.md
+++ b/pages/documentation/developer/repositories/powsybl-dynawo.md
@@ -17,5 +17,6 @@ The PowSyBl Dynawo [repository](https://github.com/powsybl/powsybl-dynawo) provi
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 1.2.0 | 2021-05-26 | [Release notes](https://github.com/powsybl/powsybl-dynawo/releases/tag/v1.2.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-dynawo/1.2.0/index.html) |
 | 1.1.0 | 2021-04-13 | [Release notes](https://github.com/powsybl/powsybl-dynawo/releases/tag/v1.1.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-dynawo/1.1.0/index.html) |
 | 1.0.0 | 2021-02-10 | [Release notes](https://github.com/powsybl/powsybl-dynawo/releases/tag/v1.0.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-dynawo/1.0.0/index.html) |

--- a/pages/documentation/developer/repositories/powsybl-entsoe.md
+++ b/pages/documentation/developer/repositories/powsybl-entsoe.md
@@ -1,0 +1,20 @@
+# powsybl-entsoe [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-entsoe.svg)](https://github.com/powsybl/powsybl-entsoe/releases/)
+The PowSyBl ENTSO-E [repository](https://github.com/powsybl/powsybl-entsoe) provides components specific to ENTSO-E-orientated processes.
+
+**Reviewers:** [annetill](https://github.com/annetill), [MioRtia](https://github.com/MioRtia), [colinepiloquet](https://github.com/colinepiloquet)  
+**Committers:** [MioRtia](https://github.com/MioRtia),  [colinepiloquet](https://github.com/colinepiloquet)
+**Release:** [MioRtia](https://github.com/MioRtia)
+
+## Features
+
+- TODO
+
+## Getting started
+
+- [Guide 1]() - TODO
+
+## Releases
+
+| Version | Release date | Release notes | API documentation |
+| ------- | ------------ | ------------- | ----------------- |
+| 1.0.0 | 2021-05-27 | [Release notes](https://github.com/powsybl/powsybl-entsoe/releases/tag/v1.0.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-entsoe/1.0.0/index.html) |

--- a/pages/documentation/developer/repositories/powsybl-open-loadflow.md
+++ b/pages/documentation/developer/repositories/powsybl-open-loadflow.md
@@ -18,6 +18,7 @@ The PowSyBl Open Load Flow [repository](https://github.com/powsybl/powsybl-open-
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 0.11.0 | 2021-05-27 | [Release notes](https://github.com/powsybl/powsybl-open-loadflow/releases/tag/v0.11.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-open-loadflow/0.11.0/index.html) |
 | 0.10.1 | 2021-04-13 | [Release notes](https://github.com/powsybl/powsybl-open-loadflow/releases/tag/v0.10.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-open-loadflow/0.10.1/index.html) |
 | 0.10.0 | 2021-04-12 | [Release notes](https://github.com/powsybl/powsybl-open-loadflow/releases/tag/v0.10.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-open-loadflow/0.10.0/index.html) |
 | 0.9.0 | 2021-02-11 | [Release notes](https://github.com/powsybl/powsybl-open-loadflow/releases/tag/v0.9.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-open-loadflow/0.9.0/index.html) |

--- a/pages/documentation/developer/repositories/powsybl-single-line-diagram.md
+++ b/pages/documentation/developer/repositories/powsybl-single-line-diagram.md
@@ -23,6 +23,7 @@ This [repository](https://github.com/powsybl/powsybl-single-line-diagram) provid
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 2.2.0 | 2021-05-26 | [Release notes](https://github.com/powsybl/powsybl-single-line-diagram/releases/tag/v2.2.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-single-line-diagram/2.2.0/index.html) |
 | 2.1.0 | 2021-04-09 | [Release notes](https://github.com/powsybl/powsybl-single-line-diagram/releases/tag/v2.1.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-single-line-diagram/2.1.0/index.html) |
 | 2.0.0 | 2021-02-09 | [Release notes](https://github.com/powsybl/powsybl-single-line-diagram/releases/tag/v2.0.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-single-line-diagram/2.0.0/index.html) |
 | 1.9.1 | 2021-04-02 | [Release notes](https://github.com/powsybl/powsybl-single-line-diagram/releases/tag/v1.9.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-single-line-diagram/1.9.1/index.html) |

--- a/pages/documentation/developer/repositories/pypowsybl.md
+++ b/pages/documentation/developer/repositories/pypowsybl.md
@@ -1,4 +1,4 @@
-# pypowsybl
+# pypowsybl [![GitHub release](https://img.shields.io/github/release/powsybl/pypowsybl.svg)](https://github.com/powsybl/pypowsybl/releases/)
 The PyPowSyBl project gives access to PowSyBl framework to Python developers. This Python integration relies on GraalVM to compile Java code to a native library.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg), [sylvlecl](https://github.com/sylvlecl)  
@@ -29,3 +29,5 @@ The available features are:
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 0.7.0 | 2021-04-13 | [Release notes](https://github.com/powsybl/pypowsybl/releases/tag/v0.6.0) | [readthedocs.io](https://pypowsybl.readthedocs.io/en/latest/) |
+| 0.6.0 | 2021-04-08 | [Release notes](https://github.com/powsybl/pypowsybl/releases/tag/v0.6.0) | - |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Doc update


**What is the current behavior?** *(You can also link to an open issue here)*
Latest versions are missing from the releases tables
PowSyBl ENTSO-E is missing a repository page


**What is the new behavior (if this is a feature change)?**
Many releases have been added
- powsybl-core 4.1.1, 4.1.2, 4.2.0
- powsybl-dynawo 1.2.0
- powsybl-open-loadflow 0.11.0
- poswybl-single-line-diagram 2.2.0
- poswybl-balances-adjustment 1.3.0, 1.4.0, 1.5.0
- pypowsybl 0.6.0, 0.7.0
- powsybl-entsoe 1.0.0