### PR TITLE
Replace all links to powsybl.slack.com by an invitation link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,7 @@
                 <p class="text-lg-right text-center pt-2 pt-lg-0">
                     <a href="https://github.com/powsybl"><i class="ri-github-fill ri-2x mr-3"></i></a>
                     <a href="https://spectrum.chat/powsybl"><i class="ri-spectrum-fill ri-2x mx-3"></i></a>
-                    <a href="https://powsybl.slack.com"><i class="ri-slack-fill ri-2x ml-3"></i></a>
+                    <a href="https://join.slack.com/t/powsybl/shared_invite/zt-rzvbuzjk-nxi0boim1RKPS5PjieI0rA"><i class="ri-slack-fill ri-2x ml-3"></i></a>
                 </p>
                 <nav class="footer-links text-lg-right text-center pt-2 pt-lg-0">
                     <a href="/pages/overview">About</a>

--- a/pages/community/index.md
+++ b/pages/community/index.md
@@ -22,7 +22,7 @@ Our [spectrum](https://spectrum.chat/powsybl) is another place to discuss or ask
 ### Slack
 ![Slack](img/index/slack-logo.png){: width="300" .center-image}
 
-We have recently moved to the [Powsybl Slack](https://powsybl.slack.com) organization for all chat.
+We have recently moved to the [Powsybl Slack](https://join.slack.com/t/powsybl/shared_invite/zt-rzvbuzjk-nxi0boim1RKPS5PjieI0rA) organization for all chat.
 
 ## Reporting bugs
 <p style="text-align:center">

--- a/pages/overview/index.md
+++ b/pages/overview/index.md
@@ -10,7 +10,7 @@ layout: default
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=com.powsybl%3Apowsybl-core&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.powsybl%3Apowsybl-core)
 [![MPL-2.0 License](https://img.shields.io/badge/license-MPL_2.0-blue.svg)](https://www.mozilla.org/en-US/MPL/2.0/)
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/powsybl)
-[![Slack](https://img.shields.io/badge/slack-powsybl-blueviolet.svg?logo=slack)](https://powsybl.slack.com)
+[![Slack](https://img.shields.io/badge/slack-powsybl-blueviolet.svg?logo=slack)](https://join.slack.com/t/powsybl/shared_invite/zt-rzvbuzjk-nxi0boim1RKPS5PjieI0rA)
 [![Javadocs](https://www.javadoc.io/badge/com.powsybl/powsybl-core.svg?color=blue)](https://www.javadoc.io/doc/com.powsybl/powsybl-core)
 
 PowSyBl (<b>Pow</b>er <b>Sy</b>stem <b>Bl</b>ocks) is an open source framework written in Java,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Slack links


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, all slack links go to powsybl.slack.com


**What is the new behavior (if this is a feature change)?**
We replace all existing link to slack by invitation link that never expires


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
