### PR TITLE
Add powsybl-math-native 1.0.4 release

### DIFF
--- a/pages/documentation/developer/repositories/powsybl-math-native.md
+++ b/pages/documentation/developer/repositories/powsybl-math-native.md
@@ -16,6 +16,7 @@ This [repository](https://github.com/powsybl/powsybl-math-native) provides a C++
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
+| 1.0.4 | 2021-09-13 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.4) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.4/index.html) |
 | 1.0.3 | 2020-07-24 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.3) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.3/index.html) |
 | 1.0.2 | 2020-04-15 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.2) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.2/index.html) |
 | 1.0.1 | 2019-09-09 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.1/index.html) |

--- a/pages/documentation/developer/repositories/powsybl-math-native.md
+++ b/pages/documentation/developer/repositories/powsybl-math-native.md
@@ -16,8 +16,8 @@ This [repository](https://github.com/powsybl/powsybl-math-native) provides a C++
 
 | Version | Release date | Release notes | API documentation |
 | ------- | ------------ | ------------- | ----------------- |
-| 1.0.4 | 2021-09-13 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.4) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.4/index.html) |
-| 1.0.3 | 2020-07-24 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.3) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.3/index.html) |
-| 1.0.2 | 2020-04-15 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.2) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.2/index.html) |
-| 1.0.1 | 2019-09-09 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.1) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.1/index.html) |
-| 1.0.0 | 2019-06-24 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.0) | [Javadoc](https://javadoc.io/doc/com.powsybl/powsybl-math-native/1.0.0/index.html) |
+| 1.0.4 | 2021-09-13 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.4) | - |
+| 1.0.3 | 2020-07-24 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.3) | - |
+| 1.0.2 | 2020-04-15 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.2) | - |
+| 1.0.1 | 2019-09-09 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.1) | - |
+| 1.0.0 | 2019-06-24 | [Release notes](https://github.com/powsybl/powsybl-math-native/releases/tag/v1.0.0) | - |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Docs update


**What is the current behavior?** *(You can also link to an open issue here)*
- Release of math-native 1.0.4 missing in tables (and in its repo)
- Javadoc links link to empty doc pages


**What is the new behavior (if this is a feature change)?**
- Release of math-native 1.0.4 added in the tables (and in the corresponding repo)
- Javadoc links removed

