### PR TITLE
Fix badges: highest version instead of latest

### DIFF
--- a/pages/documentation/developer/repositories/index.md
+++ b/pages/documentation/developer/repositories/index.md
@@ -4,55 +4,55 @@ This page shortly describes each repository of the [PowSyBl organization](https:
 
 ## Java libraries
 
-### [powsybl-core](powsybl-core.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-core.svg)](https://github.com/powsybl/powsybl-core/releases/)
+### [powsybl-core](powsybl-core.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-core.svg?sort=semver)](https://github.com/powsybl/powsybl-core/releases/)
 This [repository](https://github.com/powsybl/powsybl-core) provides the core feature of the PowSyBl framework such as the grid modelling, the support of several data exchange format (CGMES, UCTE...), computation APIs (power flow, security analysis, sensitivity analysis, dynamic simulation...).
 
 **Reviewers:** [annetill](https://github.com/annetill), [mathbagu](https://github.com/mathbagu), [MioRtia](https://github.com/MioRtia), [zamarrenolm](https://github.com/zamarrenolm)
 **Committers:** [mathbagu](https://github.com/mathbagu), [MioRtia](https://github.com/MioRtia)
 
-### [powsybl-open-loadflow](powsybl-open-loadflow.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-open-loadflow.svg)](https://github.com/powsybl/powsybl-open-loadflow/releases/)
+### [powsybl-open-loadflow](powsybl-open-loadflow.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-open-loadflow.svg?sort=semver)](https://github.com/powsybl/powsybl-open-loadflow/releases/)
 This [repository](https://github.com/powsybl/powsybl-open-loadflow) provides an implementation of the LoadFlow API based on the [powsybl-math-native](powsybl-math-native.md) project.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg)
 **Release:** [geofjamg](https://github.com/geofjamg), [mathbagu](https://github.com/mathbagu)
 
-### [powsybl-dynawo](powsybl-dynawo.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-dynawo.svg)](https://github.com/powsybl/powsybl-dynawo/releases/)
+### [powsybl-dynawo](powsybl-dynawo.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-dynawo.svg?sort=semver)](https://github.com/powsybl/powsybl-dynawo/releases/)
 This [repository](https://github.com/powsybl/powsybl-dynawo) provides an implementation of the dynamic simulation API for the [Dyna&omega;o](https://dynawo.github.io/) time domain simulation tool.
 
 **Reviewers:** [agnesLeroy](https://github.com/agnesLeroy), [mathbagu](https://github.com/mathbagu), [zamarrenolm](https://github.com/zamarrenolm)
 **Committers** [mathbagu](https://github.com/mathbagu)
 
-### [powsybl-afs](powsybl-afs.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-afs.svg)](https://github.com/powsybl/powsybl-afs/releases/)
+### [powsybl-afs](powsybl-afs.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-afs.svg?sort=semver)](https://github.com/powsybl/powsybl-afs/releases/)
 This [repository](https://github.com/powsybl/powsybl-afs) provides a standardized way to organize the data for a power system study, called AFS (**A**pplication **F**ile **S**ystem). It supports several storage system such as [MapDB](http://www.mapdb.org) or [Apache Cassandra](https://cassandra.apache.org). It is designed to be extensible using custom plugins to manage new types of data.
 
 **Reviewers:** [pl-buiquang](https://github.com/pl-buiquang), [geofjamg](https://github.com/geofjamg)
 **Committers:** [pl-buiquang](https://github.com/pl-buiquang), [mathbagu](https://github.com/mathbagu), [MioRtia](https://github.com/MioRtia)
 
-### [powsybl-hpc](powsybl-hpc.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-hpc.svg)](https://github.com/powsybl/powsybl-hpc/releases/)
+### [powsybl-hpc](powsybl-hpc.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-hpc.svg?sort=semver)](https://github.com/powsybl/powsybl-hpc/releases/)
 This [repository](https://github.com/powsybl/powsybl-hpc) provides two implementations of the Computation API, to distribute the computation using [MPI](https://www.open-mpi.org) or [Slurm Workload Manager](https://slurm.schedmd.com).
 
 **Reviewers:** [sylvlecl](https://github.com/sylvlecl) (Slurm), [geofjamg](https://github.com/geofjamg) (MPI)
 **Committers:** [sylvlecl](https://github.com/sylvlecl)
 
-### [powsybl-balances-adjustment](powsybl-balances-adjustment.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-balances-adjustment.svg)](https://github.com/powsybl/powsybl-balances-adjustment/releases/)
+### [powsybl-balances-adjustment](powsybl-balances-adjustment.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-balances-adjustment.svg?sort=semver)](https://github.com/powsybl/powsybl-balances-adjustment/releases/)
 This [repository](https://github.com/powsybl/powsybl-balances-adjustment) provides a functional module to reach target net positions across networks, through an iterative process based on power flow computations and injections scaling.
 
 **Reviewers:** [murgeyseb](https://github.com/murgeyseb)
 **Committers:** [murgeyseb](https://github.com/murgeyseb)
 
-### [powsybl-single-line-diagram](powsybl-single-line-diagram.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-single-line-diagram.svg)](https://github.com/powsybl/powsybl-single-line-diagram/releases/)
+### [powsybl-single-line-diagram](powsybl-single-line-diagram.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-single-line-diagram.svg?sort=semver)](https://github.com/powsybl/powsybl-single-line-diagram/releases/)
 This [repository](https://github.com/powsybl/powsybl-single-line-diagram) provides modules to generate single line diagrams.
 
 **Reviewers:** [flo-dup](https://github.com/flo-dup), [geofjamg](https://github.com/geofjamg), [jonenst](https://github.com/jonenst)
 **Committers:** [flo-dup](https://github.com/flo-dup), [geofjamg](https://github.com/geofjamg), [jonenst](https://github.com/jonenst)
 
-### [powsybl-entsoe](powsybl-entsoe.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-entsoe.svg)](https://github.com/powsybl/powsybl-entsoe/releases/)
+### [powsybl-entsoe](powsybl-entsoe.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-entsoe.svg?sort=semver)](https://github.com/powsybl/powsybl-entsoe/releases/)
 This [repository](https://github.com/powsybl/powsybl-entsoe) provides components specific to ENTSO-E-orientated processes.
 
 **Reviewers:** [MioRtia](https://github.com/MioRtia), [annetill](https://github.com/annetill), [colinepiloquet](https://github.com/colinepiloquet)
 **Committers:** [MioRtia](https://github.com/MioRtia),  [colinepiloquet](https://github.com/colinepiloquet)
 
-### [powsybl-metrix](powsybl-metrix.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-metrix.svg)](https://github.com/powsybl/powsybl-metrix/releases/)
+### [powsybl-metrix](powsybl-metrix.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-metrix.svg?sort=semver)](https://github.com/powsybl/powsybl-metrix/releases/)
 This [repository](https://github.com/powsybl/powsybl-metrix) provides modules to run optimal power load flow on several network variants. Variants are generated through time series mapping on a base case.
 
 **Reviewers:** [marifunf](https://github.com/marifunf), [berthaultval](https://github.com/berthaultval), [pl-buiquang](https://github.com/pl-buiquang)
@@ -104,19 +104,19 @@ This [repository](https://github.com/powsybl/powsybl-network-map-server) provide
 
 ## C++ libraries
 
-### [powsybl-iidm4cpp](powsybl-iidm4cpp.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-iidm4cpp.svg)](https://github.com/powsybl/powsybl-iidm4cpp/releases/)
+### [powsybl-iidm4cpp](powsybl-iidm4cpp.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-iidm4cpp.svg?sort=semver)](https://github.com/powsybl/powsybl-iidm4cpp/releases/)
 This [repository](https://github.com/powsybl/powsybl-iidm4cpp) provides a C++ implementation of the IIDM grid model.
 
 **Reviewers:** [mathbagu](https://github.com/mathbagu)
 **Committers:** [mathbagu](https://github.com/mathbagu)
 
-### [powsybl-math-native](powsybl-math-native.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-math-native.svg)](https://github.com/powsybl/powsybl-math-native/releases/)
+### [powsybl-math-native](powsybl-math-native.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-math-native.svg?sort=semver)](https://github.com/powsybl/powsybl-math-native/releases/)
 This [repository](https://github.com/powsybl/powsybl-math-native) provides a C++ implementation of sparse matrix, based on the [SuiteSparse](http://faculty.cse.tamu.edu/davis/suitesparse.html) project. This 64-bits libraries for Linux, Windows and MacOS are packaged as a Jar file and published on maven central.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg), [mathbagu](https://github.com/mathbagu)
 **Committers:** [geofjamg](https://github.com/geofjamg), [mathbagu](https://github.com/mathbagu)
 
-### [powsybl-metrix](powsybl-metrix.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-metrix.svg)](https://github.com/powsybl/powsybl-metrix/releases/)
+### [powsybl-metrix](powsybl-metrix.md) [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-metrix.svg?sort=semver)](https://github.com/powsybl/powsybl-metrix/releases/)
 This [repository](https://github.com/powsybl/powsybl-metrix) provides a C++ implementation of optimal power load flow.
 
 **Reviewers:** [berthaultval](https://github.com/berthaultval), [marifunf](https://github.com/marifunf), [pl-buiquang](https://github.com/pl-buiquang)
@@ -124,7 +124,7 @@ This [repository](https://github.com/powsybl/powsybl-metrix) provides a C++ impl
 
 ## Development
 
-### [pypowsybl](pypowsybl.md) [![GitHub release](https://img.shields.io/github/release/powsybl/pypowsybl.svg)](https://github.com/powsybl/pypowsybl/releases/)
+### [pypowsybl](pypowsybl.md) [![GitHub release](https://img.shields.io/github/release/powsybl/pypowsybl.svg?sort=semver)](https://github.com/powsybl/pypowsybl/releases/)
 
 This [repository](https://github.com/powsybl/pypowsybl) provides an integration of the PowSyBl framework for Python developers.
 
@@ -136,7 +136,7 @@ This [repository](https://github.com/powsybl/powsybl-incubator) provides incubat
 
 **Reviewers:** all the committers
 
-### powsybl-parent [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-parent.svg)](https://github.com/powsybl/powsybl-parent/releases/)
+### powsybl-parent [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-parent.svg?sort=semver)](https://github.com/powsybl/powsybl-parent/releases/)
 This [repository](https://github.com/powsybl/powsybl-parent) provides the build configuration shared as maven pom files, shared by all our Java repositories.
 
 **Reviewers:** [jonenst](https://github.com/jonenst), [mathbagu](https://github.com/mathbagu)

--- a/pages/documentation/developer/repositories/powsybl-afs.md
+++ b/pages/documentation/developer/repositories/powsybl-afs.md
@@ -1,4 +1,4 @@
-# powsybl-afs [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-afs.svg)](https://github.com/powsybl/powsybl-afs/releases/)
+# powsybl-afs [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-afs.svg?sort=semver)](https://github.com/powsybl/powsybl-afs/releases/)
 The PowSyBl AFS (**A**pplication **F**ile **S**ystem) [repository](https://github.com/powsybl/powsybl-afs) provides a standardized way to organize the data for a power system study. It supports several storage system such as [MapDB](http://www.mapdb.org) or [Apache Cassandra](https://cassandra.apache.org). It is designed to be extensible using custom plugins to manage new types of data.
 
 **Reviewers:** [pl-buiquang](https://github.com/pl-buiquang), [geofjamg](https://github.com/geofjamg)  

--- a/pages/documentation/developer/repositories/powsybl-balances-adjustment.md
+++ b/pages/documentation/developer/repositories/powsybl-balances-adjustment.md
@@ -1,4 +1,4 @@
-# powsybl-balances-adjustment [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-balances-adjustment.svg)](https://github.com/powsybl/powsybl-balances-adjustment/releases/)
+# powsybl-balances-adjustment [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-balances-adjustment.svg?sort=semver)](https://github.com/powsybl/powsybl-balances-adjustment/releases/)
 The PowSyBl Balances Adjustment [repository](https://github.com/powsybl/powsybl-balances-adjustment) provides a functional module to reach target net positions across networks, through an iterative process based on power flow computations and injections scaling.
 
 **Reviewers:** [murgeyseb](https://github.com/murgeyseb)  

--- a/pages/documentation/developer/repositories/powsybl-core.md
+++ b/pages/documentation/developer/repositories/powsybl-core.md
@@ -1,4 +1,4 @@
-# powsybl-core [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-core.svg)](https://github.com/powsybl/powsybl-core/releases/)
+# powsybl-core [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-core.svg?sort=semver)](https://github.com/powsybl/powsybl-core/releases/)
 The PowSyBl Core [repository](https://github.com/powsybl/powsybl-core) provides the core features of the framework and a large set of APIs to import/export grid data or run various type of simulations (power flow, security analysis, sensitivity calculation, time domain simulation).
 
 **Reviewers:** [annetill](https://github.com/annetill), [mathbagu](https://github.com/mathbagu), [MioRtia](https://github.com/MioRtia), [zamarrenolm](https://github.com/zamarrenolm)  

--- a/pages/documentation/developer/repositories/powsybl-dynawo.md
+++ b/pages/documentation/developer/repositories/powsybl-dynawo.md
@@ -1,4 +1,4 @@
-# powsybl-dynawo [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-dynawo.svg)](https://github.com/powsybl/powsybl-dynawo/releases/)
+# powsybl-dynawo [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-dynawo.svg?sort=semver)](https://github.com/powsybl/powsybl-dynawo/releases/)
 The PowSyBl Dynawo [repository](https://github.com/powsybl/powsybl-dynawo) provides an implementation of the dynamic simulation API for the [Dyna&omega;o](https://dynawo.github.io/) time domain simulation tool.
 
 **Reviewers:** [agnesLeroy](https://github.com/agnesLeroy), [mathbagu](https://github.com/mathbagu), [zamarrenolm](https://github.com/zamarrenolm)  

--- a/pages/documentation/developer/repositories/powsybl-entsoe.md
+++ b/pages/documentation/developer/repositories/powsybl-entsoe.md
@@ -1,4 +1,4 @@
-# powsybl-entsoe [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-entsoe.svg)](https://github.com/powsybl/powsybl-entsoe/releases/)
+# powsybl-entsoe [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-entsoe.svg?sort=semver)](https://github.com/powsybl/powsybl-entsoe/releases/)
 The PowSyBl ENTSO-E [repository](https://github.com/powsybl/powsybl-entsoe) provides components specific to ENTSO-E-orientated processes.
 
 **Reviewers:** [annetill](https://github.com/annetill), [MioRtia](https://github.com/MioRtia), [colinepiloquet](https://github.com/colinepiloquet)  

--- a/pages/documentation/developer/repositories/powsybl-hpc.md
+++ b/pages/documentation/developer/repositories/powsybl-hpc.md
@@ -1,4 +1,4 @@
-# powsybl-hpc [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-hpc.svg)](https://github.com/powsybl/powsybl-hpc/releases/)
+# powsybl-hpc [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-hpc.svg?sort=semver)](https://github.com/powsybl/powsybl-hpc/releases/)
 The PowSyBl HPC (High Performance Computing) [repository](https://github.com/powsybl/powsybl-hpc) provides two implementations of the Computation API, to distribute the computation using [MPI](https://www.open-mpi.org) or [Slurm Workload Manager](https://slurm.schedmd.com).
 
 **Reviewers:** [sylvlecl](https://github.com/sylvlecl) (Slurm), [geofjamg](https://github.com/geofjamg) (MPI)  

--- a/pages/documentation/developer/repositories/powsybl-iidm4cpp.md
+++ b/pages/documentation/developer/repositories/powsybl-iidm4cpp.md
@@ -1,4 +1,4 @@
-# powsybl-iidm4cpp [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-iidm4cpp.svg)](https://github.com/powsybl/powsybl-iidm4cpp/releases/)
+# powsybl-iidm4cpp [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-iidm4cpp.svg?sort=semver)](https://github.com/powsybl/powsybl-iidm4cpp/releases/)
 This [repository](https://github.com/powsybl/powsybl-iidm4cpp) provides a C++ implementation of the IIDM grid model.
 
 **Reviewers:** [mathbagu](https://github.com/mathbagu)  

--- a/pages/documentation/developer/repositories/powsybl-math-native.md
+++ b/pages/documentation/developer/repositories/powsybl-math-native.md
@@ -1,4 +1,4 @@
-# powsybl-math-native [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-math-native.svg)](https://github.com/powsybl/powsybl-math-native/releases/)
+# powsybl-math-native [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-math-native.svg?sort=semver)](https://github.com/powsybl/powsybl-math-native/releases/)
 This [repository](https://github.com/powsybl/powsybl-math-native) provides a C++ implementation of sparse matrix, based on the [SuiteSparse](http://faculty.cse.tamu.edu/davis/suitesparse.html) project. These 64-bits libraries for Linux, Windows and MacOS are packaged as a Jar file and published on maven central.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg), [mathbagu](https://github.com/mathbagu)  

--- a/pages/documentation/developer/repositories/powsybl-metrix.md
+++ b/pages/documentation/developer/repositories/powsybl-metrix.md
@@ -1,4 +1,4 @@
-# powsybl-metrix [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-metrix.svg)](https://github.com/powsybl/powsybl-metrix/releases/)
+# powsybl-metrix [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-metrix.svg?sort=semver)](https://github.com/powsybl/powsybl-metrix/releases/)
 The PowSyBl Metrix [repository](https://github.com/powsybl/powsybl-metrix) provides modules to run optimal power load flow on several network variants. Variants are generated through time series mapping on a base case.
 
 **Reviewers:** [berthaultval](https://github.com/berthaultval), [marifunf](https://github.com/marifunf), [pl-buiquang](https://github.com/pl-buiquang)  

--- a/pages/documentation/developer/repositories/powsybl-open-loadflow.md
+++ b/pages/documentation/developer/repositories/powsybl-open-loadflow.md
@@ -1,4 +1,4 @@
-# powsybl-open-loadflow [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-open-loadflow.svg)](https://github.com/powsybl/powsybl-open-loadflow/releases/)
+# powsybl-open-loadflow [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-open-loadflow.svg?sort=semver)](https://github.com/powsybl/powsybl-open-loadflow/releases/)
 The PowSyBl Open Load Flow [repository](https://github.com/powsybl/powsybl-open-loadflow) provides an implementation of the LoadFlow API based on the [powsybl-math-native](powsybl-math-native.md) project.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg), [annetill](https://github.com/annetill)  

--- a/pages/documentation/developer/repositories/powsybl-single-line-diagram.md
+++ b/pages/documentation/developer/repositories/powsybl-single-line-diagram.md
@@ -1,4 +1,4 @@
-# powsybl-single-line-diagram [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-single-line-diagram.svg)](https://github.com/powsybl/powsybl-single-line-diagram/releases/)
+# powsybl-single-line-diagram [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-single-line-diagram.svg?sort=semver)](https://github.com/powsybl/powsybl-single-line-diagram/releases/)
 This [repository](https://github.com/powsybl/powsybl-single-line-diagram) provides modules to generate single line diagrams.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg), [jonenst](https://github.com/jonenst), [flo-dup](https://github.com/flo-dup)  

--- a/pages/documentation/developer/repositories/pypowsybl.md
+++ b/pages/documentation/developer/repositories/pypowsybl.md
@@ -1,4 +1,4 @@
-# pypowsybl [![GitHub release](https://img.shields.io/github/release/powsybl/pypowsybl.svg)](https://github.com/powsybl/pypowsybl/releases/)
+# pypowsybl [![GitHub release](https://img.shields.io/github/release/powsybl/pypowsybl.svg?sort=semver)](https://github.com/powsybl/pypowsybl/releases/)
 The PyPowSyBl project gives access to PowSyBl framework to Python developers. This Python integration relies on GraalVM to compile Java code to a native library.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg), [sylvlecl](https://github.com/sylvlecl)  


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Latest version is displayed on shields.io badges instead of highest version (SemVer), leading to for instance for core: ![core-ko](https://img.shields.io/github/release/powsybl/powsybl-core.svg) (3.7.2 as of today)


**What is the new behavior (if this is a feature change)?**
Highest version displayed: for instance for core ![core-ok](https://img.shields.io/github/release/powsybl/powsybl-core.svg?sort=semver) (4.4.0 as of today)
