### PR TITLE
Remove half line mentions in tie line description

### DIFF
--- a/pages/documentation/grid/model/index.md
+++ b/pages/documentation/grid/model/index.md
@@ -493,13 +493,11 @@ $$
 ##### Tie Line
 [![Javadoc](https://img.shields.io/badge/-javadoc-blue.svg)](https://javadoc.io/doc/com.powsybl/powsybl-core/latest/com/powsybl/iidm/network/TieLine.html)
 
-A tie line is an AC line sharing power between two neighbouring regional grids. It is constituted of two [half lines](#half-line).
-A tie line is created by matching two [dangling lines](#dangling-line) with the same Xnode code.
-It has line characteristics, with $$R$$ (resp. $$X$$) being the sum of the series resistances (resp. reactances) of the two half lines.
-$$G1$$ (resp. $$B1$$) is equal to the sum of the first half line's $$G1$$ and $$G2$$ (resp. $$B1$$ and $$B2$$).
-$$G2$$ (resp. $$B2$$) is equal to the sum of the second half line's $$G1$$ and $$G2$$ (resp. $$B1$$ and $$B2$$).
-
-###### Half Line
+A tie line is an AC line sharing power between two neighbouring regional grids.
+It is created by matching two [dangling lines](#dangling-line) with the same Xnode code.
+It has line characteristics, with $$R$$ (resp. $$X$$) being the sum of the series resistances (resp. reactances) of the two dangling lines.
+$$G1$$ (resp. $$B1$$) is equal to the first dangling line's $$G1$$ (resp. $$B1$$).
+$$G2$$ (resp. $$B2$$) is equal to the second dangling line's $$G2$$ (resp. $$B2$$).
 
 **Characteristics**
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Documentation update


**What is the current behavior?**
Half lines are still metionned in the tie line description.



**What is the new behavior (if this is a feature change)?**
The tie line description now mentions dangling lines and thus is consistent with powsybl-core latest versions (dangling lines have replaced half lines since powsybl-core v5.3.0).



**Does this PR introduce a breaking change or deprecate an API?**
No
