### PR TITLE
Fix drawing of temporary limit

### DIFF
--- a/pages/documentation/developer/api_guide/img/limits/currentLimitsExample1.svg
+++ b/pages/documentation/developer/api_guide/img/limits/currentLimitsExample1.svg
@@ -53,7 +53,7 @@ text {font-size:13.75px;font-family:sans-serif;fill:#000000}
        y="155">120</text>
     <text
        x="100"
-       y="195">acceptable 120 s</text>
+       y="195">acceptable 1200 s</text>
     <path
        class="dashed-line1"
        d="M 37,150 H 260" />
@@ -65,7 +65,7 @@ text {font-size:13.75px;font-family:sans-serif;fill:#000000}
        y="75">140</text>
     <text
        x="100"
-       y="115">acceptable 60 s</text>
+       y="115">acceptable 600 s</text>
     <path
        class="dashed-line1"
        d="M 37,70 H 260" />


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
On the image, the temporary limits are 60 and 120s. But in the code, they are 600 and 1200s.


**What is the new behavior (if this is a feature change)?**
The code and the picture match
