### PR TITLE
Add link to documentation in navigation bar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -16,6 +16,8 @@
                 </li>
                 <li><a href="/pages/community">Community</a>
                 </li>
+                <li><a href="https://powsybl.readthedocs.io" target=”_blank”>Documentation</a>
+                </li>
             </ul>
         </nav>
     </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The navigation bar at the top of the website does not include a link to the documentation.


**What is the new behavior (if this is a feature change)?**
For quick access to the documentation, a link to the readthedocs is added (it stays wherever you are on the website so that the documentation is easily reachable). Also, the documentation website opens in a new tab.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
