### PR TITLE
Replace link to policies from US to EU LF policies

### DIFF
--- a/pages/contributing/technical-charter.html
+++ b/pages/contributing/technical-charter.html
@@ -15,9 +15,9 @@ layout: default
 <h1>Technical Charter</h1>
 
 This Charter sets forth the responsibilities and procedures for technical contribution to, and
-oversight of, the PowSyBL open source project, which has been established as a project of Linux
+oversight of, the PowSyBL open source project (the “Project”), which has been established as a project of Linux
 Foundation Europe, a Belgian private stichting headquartered at Kunstlaan 56, Brussels (“LF
-Europe”).(the “Project”). All contributors (including committers, maintainers, and other
+Europe”). All contributors (including committers, maintainers, and other
 technical positions) and other participants in the Project (collectively, “Collaborators”) must
 comply with the terms of this Charter.
 

--- a/pages/contributing/technical-charter.html
+++ b/pages/contributing/technical-charter.html
@@ -14,7 +14,14 @@ layout: default
 
 <h1>Technical Charter</h1>
 
-This charter (the “Charter”) sets forth the responsibilities and procedures for technical contribution to, and oversight of, the PowSyBl project, which has been established as PowSyBl a Series of LF Europe Projects, LLC (the “Project”). LF Europe Projects, LLC (“LF Projects”) is a Delaware series limited liability company. All contributors to the Project must comply with the terms of this Charter.
+This Charter sets forth the responsibilities and procedures for technical contribution to, and
+oversight of, the PowSyBL open source project, which has been established as a project of Linux
+Foundation Europe, a Belgian private stichting headquartered at Kunstlaan 56, Brussels (“LF
+Europe”).(the “Project”). All contributors (including committers, maintainers, and other
+technical positions) and other participants in the Project (collectively, “Collaborators”) must
+comply with the terms of this Charter.
+
+See the pdf version of this charter <a href="https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf" target="_blank">here</a>, maintained by LF Legal.
 
 <h2>1. Mission and Scope of the Project</h2>
 a. The mission of the Project is to build a modular, high performance, and industrial grade open source framework for the modeling, simulation and analytics of power systems (the "Framework"), leveraging reusable components, common APIs and a secure architecture. The Framework is intended to enable the requirements of energy transition and the rapid diffusion of distributed energy resources, and the Project seeks to develop an ecosystem of developers, suppliers, OEMs, systems integrators, and customers all using the Framework.
@@ -72,16 +79,16 @@ a. While the Project aims to operate as a consensus-based community, if any TSC 
 b. Quorum for TSC meetings requires at least fifty percent of all voting members of the TSC to be present. The TSC may continue to meet if quorum is not met but will be prevented from making any decisions at the meeting.
 <br>
 <br>
-c. Except as provided in Section <a href="#7c">7.c</a>. and <a href="#8a">8.a</a>, decisions by vote at a meeting require a majority vote of those in attendance, provided quorum is met. Decisions made by electronic vote without a meeting require a majority vote of all voting members of the TSC.
+c. Except as provided in Section <a href="#7c">7.c</a>, and <a href="#8a">8.a</a>, decisions by vote at a meeting require a majority vote of those in attendance, provided quorum is met. Decisions made by electronic vote without a meeting require a majority vote of all voting members of the TSC.
 <br>
 <br>
 d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC may refer the matter to the Series Manager for assistance in reaching a resolution.
 
 <h2>4. Compliance with Policies</h2>
-a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Europe Projects. Contributors will comply with the policies of LF Europe Projects as may be adopted and amended by LF Europe Projects, including, without limitation the policies listed at <a href="https://linuxfoundation.eu/en/policies/" target="_blank">https://linuxfoundation.eu/en/policies/</a>.
+a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Europe Projects. Contributors will comply with the policies of LF Europe Projects as may be adopted and amended by LF Europe Projects, including, without limitation the policies listed at <a href="https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf" target="_blank">https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf</a>.
 <br>
 <br>
-b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. Contributors to the Project will comply with the CoC or, in the event that a Project-specific CoC has not been approved, the LF Europe Projects Code of Conduct listed at <a href="https://linuxfoundation.eu/en/policies/" target="_blank">https://linuxfoundation.eu/en/policies/</a>.
+b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. Contributors to the Project will comply with the CoC or, in the event that a Project-specific CoC has not been approved, the LF Europe Projects Code of Conduct listed at <a href="https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf" target="_blank">https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf</a>.
 <br>
 <br>
 c. When amending or adopting any policy applicable to the Project, LF Europe Projects will publish such policy, as to be amended or adopted, on its website at least 30 days prior to such policy taking effect; provided, however, that in the case of any amendment of the Trademark Policy or Terms of Use of LF Europe Projects, any such amendment is effective upon publication on LF Project’s website.

--- a/pages/contributing/technical-charter.html
+++ b/pages/contributing/technical-charter.html
@@ -106,12 +106,12 @@ a. LF Europe will hold title to all trade or service marks used by the Project (
 b. The Project will, as permitted and in accordance with such license from LF Europe, develop and own all Project GitHub and social media accounts, and domain name registrations created by the Project community.
 <br>
 <br>
-c. Under no circumstances will LF Europe be expected or required to undertake any action on behalf of the Project that is inconsistent with the tax-exempt status or purpose, as applicable, of LFP, Inc. or LF Europe, LLC.
+c. Under no circumstances will LF Europe be expected or required to undertake any action on behalf of the Project that is inconsistent with the tax-exempt status or purpose, as applicable, of LF Europe.
 
 <h2>6. General Rules and Operations.</h2>
 a. The Project will:
 <ul>
-    <li>Engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Europe, LFP, Inc. and other partner organizations in the
+    <li>Engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Europe and other partner organizations in the
         open source software community; and</li>
     <li>Respect the rights of all trademark owners, including any branding and trademark usage guidelines.</li>
 </ul>

--- a/pages/contributing/technical-charter.html
+++ b/pages/contributing/technical-charter.html
@@ -85,33 +85,33 @@ c. Except as provided in Section <a href="#7c">7.c</a>, and <a href="#8a">8.a</a
 d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC may refer the matter to the Series Manager for assistance in reaching a resolution.
 
 <h2>4. Compliance with Policies</h2>
-a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Europe Projects. Contributors will comply with the policies of LF Europe Projects as may be adopted and amended by LF Europe Projects, including, without limitation the policies listed at <a href="https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf" target="_blank">https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf</a>.
+a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Europe. Contributors will comply with the policies of LF Europe as may be adopted and amended by LF Europe, including, without limitation the policies listed at <a href="https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf" target="_blank">https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf</a>.
 <br>
 <br>
-b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. Contributors to the Project will comply with the CoC or, in the event that a Project-specific CoC has not been approved, the LF Europe Projects Code of Conduct listed at <a href="https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf" target="_blank">https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf</a>.
+b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. Contributors to the Project will comply with the CoC or, in the event that a Project-specific CoC has not been approved, the LF Europe Code of Conduct listed at <a href="https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf" target="_blank">https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf</a>.
 <br>
 <br>
-c. When amending or adopting any policy applicable to the Project, LF Europe Projects will publish such policy, as to be amended or adopted, on its website at least 30 days prior to such policy taking effect; provided, however, that in the case of any amendment of the Trademark Policy or Terms of Use of LF Europe Projects, any such amendment is effective upon publication on LF Project’s website.
+c. When amending or adopting any policy applicable to the Project, LF Europe will publish such policy, as to be amended or adopted, on its website at least 30 days prior to such policy taking effect; provided, however, that in the case of any amendment of the Trademark Policy or Terms of Use of LF Europe, any such amendment is effective upon publication on LF Project’s website.
 <br>
 <br>
 d. All participants must allow open participation from any individual or organization meeting the requirements for contributing under this Charter and any policies adopted for all participants by the TSC, regardless of competitive interests. Put another way, the Project community must not seek to exclude any participant based on any criteria, requirement, or reason other than those that are reasonable and applied on a non-discriminatory basis to all participants in the Project community.
 <br>
 <br>
-e. The Project will operate in a transparent, open, collaborative, and ethical manner at all times. The output of all Project discussions, proposals, timelines, decisions, and status should be made open and easily visible to all. Any potential violations of this requirement should be reported immediately to the LF Europe Projects Manager.
+e. The Project will operate in a transparent, open, collaborative, and ethical manner at all times. The output of all Project discussions, proposals, timelines, decisions, and status should be made open and easily visible to all. Any potential violations of this requirement should be reported immediately to the LF Europe Manager.
 
 <h2>5. Community Assets</h2>
-a. LF Europe Projects will hold title to all trade or service marks used by the Project (“Project Trademarks”), whether based on common law or registered rights. Project Trademarks will be transferred and assigned to LF Europe Projects to hold on behalf of the Project. Any use of any Project Trademarks by participants in the Project will be in accordance with the license from LF Europe Projects and inure to the benefit of LF Europe Projects.
+a. LF Europe will hold title to all trade or service marks used by the Project (“Project Trademarks”), whether based on common law or registered rights. Project Trademarks will be transferred and assigned to LF Europe to hold on behalf of the Project. Any use of any Project Trademarks by participants in the Project will be in accordance with the license from LF Europe and inure to the benefit of LF Europe.
 <br>
 <br>
-b. The Project will, as permitted and in accordance with such license from LF Europe Projects, develop and own all Project GitHub and social media accounts, and domain name registrations created by the Project community.
+b. The Project will, as permitted and in accordance with such license from LF Europe, develop and own all Project GitHub and social media accounts, and domain name registrations created by the Project community.
 <br>
 <br>
-c. Under no circumstances will LF Europe Projects be expected or required to undertake any action on behalf of the Project that is inconsistent with the tax-exempt status or purpose, as applicable, of LFP, Inc. or LF Europe Projects, LLC.
+c. Under no circumstances will LF Europe be expected or required to undertake any action on behalf of the Project that is inconsistent with the tax-exempt status or purpose, as applicable, of LFP, Inc. or LF Europe, LLC.
 
 <h2>6. General Rules and Operations.</h2>
 a. The Project will:
 <ul>
-    <li>Engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Europe Projects, LFP, Inc. and other partner organizations in the
+    <li>Engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Europe, LFP, Inc. and other partner organizations in the
         open source software community; and</li>
     <li>Respect the rights of all trademark owners, including any branding and trademark usage guidelines.</li>
 </ul>
@@ -142,4 +142,4 @@ b. Except as described in Section <a href="#7c">7.c</a>, all contributions to th
 d. Contributed files should contain license information, such as SPDX short form identifiers, indicating the open source license or licenses pertaining to the file.
 
 <h2>8. Amendments</h2>
-<a class="heading" id="8a"></a>a. This charter may be amended by a two-thirds vote of the entire TSC and is subject to approval by LF Europe Projects.
+<a class="heading" id="8a"></a>a. This charter may be amended by a two-thirds vote of the entire TSC and is subject to approval by LF Europe.

--- a/pages/contributing/technical-charter.html
+++ b/pages/contributing/technical-charter.html
@@ -14,7 +14,7 @@ layout: default
 
 <h1>Technical Charter</h1>
 
-This charter (the “Charter”) sets forth the responsibilities and procedures for technical contribution to, and oversight of, the PowSyBl project, which has been established as PowSyBl a Series of LF Projects, LLC (the “Project”). LF Projects, LLC (“LF Projects”) is a Delaware series limited liability company. All contributors to the Project must comply with the terms of this Charter.
+This charter (the “Charter”) sets forth the responsibilities and procedures for technical contribution to, and oversight of, the PowSyBl project, which has been established as PowSyBl a Series of LF Europe Projects, LLC (the “Project”). LF Europe Projects, LLC (“LF Projects”) is a Delaware series limited liability company. All contributors to the Project must comply with the terms of this Charter.
 
 <h2>1. Mission and Scope of the Project</h2>
 a. The mission of the Project is to build a modular, high performance, and industrial grade open source framework for the modeling, simulation and analytics of power systems (the "Framework"), leveraging reusable components, common APIs and a secure architecture. The Framework is intended to enable the requirements of energy transition and the rapid diffusion of distributed energy resources, and the Project seeks to develop an ecosystem of developers, suppliers, OEMs, systems integrators, and customers all using the Framework.
@@ -78,33 +78,33 @@ c. Except as provided in Section <a href="#7c">7.c</a>. and <a href="#8a">8.a</a
 d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC may refer the matter to the Series Manager for assistance in reaching a resolution.
 
 <h2>4. Compliance with Policies</h2>
-a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Projects. Contributors will comply with the policies of LF Projects as may be adopted and amended by LF Projects, including, without limitation the policies listed at <a href="https://lfprojects.org/policies/" target="_blank">https://lfprojects.org/policies/</a>.
+a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Europe Projects. Contributors will comply with the policies of LF Europe Projects as may be adopted and amended by LF Europe Projects, including, without limitation the policies listed at <a href="https://linuxfoundation.eu/en/policies/" target="_blank">https://linuxfoundation.eu/en/policies/</a>.
 <br>
 <br>
-b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. Contributors to the Project will comply with the CoC or, in the event that a Project-specific CoC has not been approved, the LF Projects Code of Conduct listed at <a href="https://lfprojects.org/policies/" target="_blank">https://lfprojects.org/policies/</a>.
+b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. Contributors to the Project will comply with the CoC or, in the event that a Project-specific CoC has not been approved, the LF Europe Projects Code of Conduct listed at <a href="https://linuxfoundation.eu/en/policies/" target="_blank">https://linuxfoundation.eu/en/policies/</a>.
 <br>
 <br>
-c. When amending or adopting any policy applicable to the Project, LF Projects will publish such policy, as to be amended or adopted, on its website at least 30 days prior to such policy taking effect; provided, however, that in the case of any amendment of the Trademark Policy or Terms of Use of LF Projects, any such amendment is effective upon publication on LF Project’s website.
+c. When amending or adopting any policy applicable to the Project, LF Europe Projects will publish such policy, as to be amended or adopted, on its website at least 30 days prior to such policy taking effect; provided, however, that in the case of any amendment of the Trademark Policy or Terms of Use of LF Europe Projects, any such amendment is effective upon publication on LF Project’s website.
 <br>
 <br>
 d. All participants must allow open participation from any individual or organization meeting the requirements for contributing under this Charter and any policies adopted for all participants by the TSC, regardless of competitive interests. Put another way, the Project community must not seek to exclude any participant based on any criteria, requirement, or reason other than those that are reasonable and applied on a non-discriminatory basis to all participants in the Project community.
 <br>
 <br>
-e. The Project will operate in a transparent, open, collaborative, and ethical manner at all times. The output of all Project discussions, proposals, timelines, decisions, and status should be made open and easily visible to all. Any potential violations of this requirement should be reported immediately to the LF Projects Manager.
+e. The Project will operate in a transparent, open, collaborative, and ethical manner at all times. The output of all Project discussions, proposals, timelines, decisions, and status should be made open and easily visible to all. Any potential violations of this requirement should be reported immediately to the LF Europe Projects Manager.
 
 <h2>5. Community Assets</h2>
-a. LF Projects will hold title to all trade or service marks used by the Project (“Project Trademarks”), whether based on common law or registered rights. Project Trademarks will be transferred and assigned to LF Projects to hold on behalf of the Project. Any use of any Project Trademarks by participants in the Project will be in accordance with the license from LF Projects and inure to the benefit of LF Projects.
+a. LF Europe Projects will hold title to all trade or service marks used by the Project (“Project Trademarks”), whether based on common law or registered rights. Project Trademarks will be transferred and assigned to LF Europe Projects to hold on behalf of the Project. Any use of any Project Trademarks by participants in the Project will be in accordance with the license from LF Europe Projects and inure to the benefit of LF Europe Projects.
 <br>
 <br>
-b. The Project will, as permitted and in accordance with such license from LF Projects, develop and own all Project GitHub and social media accounts, and domain name registrations created by the Project community.
+b. The Project will, as permitted and in accordance with such license from LF Europe Projects, develop and own all Project GitHub and social media accounts, and domain name registrations created by the Project community.
 <br>
 <br>
-c. Under no circumstances will LF Projects be expected or required to undertake any action on behalf of the Project that is inconsistent with the tax-exempt status or purpose, as applicable, of LFP, Inc. or LF Projects, LLC.
+c. Under no circumstances will LF Europe Projects be expected or required to undertake any action on behalf of the Project that is inconsistent with the tax-exempt status or purpose, as applicable, of LFP, Inc. or LF Europe Projects, LLC.
 
 <h2>6. General Rules and Operations.</h2>
 a. The Project will:
 <ul>
-    <li>Engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Projects, LFP, Inc. and other partner organizations in the
+    <li>Engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Europe Projects, LFP, Inc. and other partner organizations in the
         open source software community; and</li>
     <li>Respect the rights of all trademark owners, including any branding and trademark usage guidelines.</li>
 </ul>
@@ -135,4 +135,4 @@ b. Except as described in Section <a href="#7c">7.c</a>, all contributions to th
 d. Contributed files should contain license information, such as SPDX short form identifiers, indicating the open source license or licenses pertaining to the file.
 
 <h2>8. Amendments</h2>
-<a class="heading" id="8a"></a>a. This charter may be amended by a two-thirds vote of the entire TSC and is subject to approval by LF Projects.
+<a class="heading" id="8a"></a>a. This charter may be amended by a two-thirds vote of the entire TSC and is subject to approval by LF Europe Projects.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Change the reference from LF US charter (https://lfprojects.org/policies/) to Europe one.

Get the conent from the LF legal maintained charter [here](https://github.com/lf-energy/foundation/blob/main/project_charters/powsybl_charter.pdf) 

